### PR TITLE
fix: handle unchecked errors from Close and Disconnect

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create GridFS client: %v", err)
 	}
-	defer client.Disconnect(ctx)
+	defer func() {
+		if err := client.Disconnect(ctx); err != nil {
+			log.Fatalf("Failed to disconnect from MongoDB: %v", err)
+		}
+	}()
 
 	// Concurrently download files
 	var wg sync.WaitGroup

--- a/pkg/fileops/fileops.go
+++ b/pkg/fileops/fileops.go
@@ -16,14 +16,17 @@ func FileExistsAndNotEmpty(filename string) bool {
 }
 
 // ReadFileNames reads file names from the given file.
-func ReadFileNames(filename string) ([]string, error) {
+func ReadFileNames(filename string) (names []string, err error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
-	var names []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())


### PR DESCRIPTION
This change fixes four lint issues reported by errcheck by adding error handling for deferred Close and Disconnect calls.

The following files were modified:
- main.go
- pkg/fileops/fileops.go
- pkg/gridfs/gridfs.go

In all cases, the deferred call was wrapped in an anonymous function that checks the returned error. For functions that return an error, a named return value is used to propagate the error from the deferred call.